### PR TITLE
Add support for TOML config cli files

### DIFF
--- a/docs/cli-options-usage.md
+++ b/docs/cli-options-usage.md
@@ -40,24 +40,40 @@ additional parsing failures!
 
 ## Config Files
 
-It is possible to provide options to the CLI via a `.ini` configuration file. The path to the file
-can be provided using the CLI's `--config` option, or the environment variable `CLI_CONFIG_PATH`. If
-no path is provided, the CLI will default to checking the root of the current working directory for
-a file by the name of `fortran_cli_config.ini`.
+It is possible to provide options to the CLI via a `.ini` or `.toml` configuration file. The path to the file
+can be provided using the CLI's `--config` option, or the environment variable `CLI_CONFIG_PATH`.
 
 The base options that are required for *every* command are listed under a section titled `options`.
 Options specific to a certain command are listed under a section with the title format
 `options.command`, where `command` is the name of the command. The names of the settings in the
-`.ini` file are the same as the names of the flags in the CLI, with the only difference being the
+config file are the same as the names of the flags in the CLI, with the only difference being the
 hyphens (`-`) are instead underscores (`_`).
 
-Below is an example that shows the format of a config file for the application:
+Below is an example that shows the format of both a `.ini` and `.toml` config file for the
+application:
 
+### INI Config
 ```ini
 [options]
 code_path = .
 output_format = json
 output_path = ./results.json
+fortran_only = true
+
+[options.get-summary]
+top_level_blocks = true
+top_level_vars = false
+
+[options.list-all-variables]
+no_duplicates = true
+```
+
+### TOML Config
+```toml
+[options]
+code_path = "."
+output_format = "json"
+output_path = "./results.json"
 fortran_only = true
 
 [options.get-summary]

--- a/src/python/tests/integration/test_fortran_cli.py
+++ b/src/python/tests/integration/test_fortran_cli.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -18,7 +19,7 @@ class TestFortranCLI:
 
     @pytest.fixture
     def live_data_path(self):
-        return "./src/python/tests/integration/.live_test_data/Fortran"
+        return os.path.abspath("./src/python/tests/integration/.live_test_data/Fortran")
 
     def test_check_output_path_file_extension(self, runner, live_data_path):
         expected_error_message = (
@@ -110,7 +111,7 @@ class TestFortranCLI:
             f.write("top_level_vars = false\n")
 
         expected_output = "Results serialized successfully"
-        result = runner.invoke(cli, ["--config", config_path, "get-summary"])
+        result = runner.invoke(cli, ["--config", str(config_path), "get-summary"])
 
         assert result.exit_code == 0
         assert expected_output in result.output


### PR DESCRIPTION
This change adds the ability to supply CLI options via a TOML file. I opted to do this for two reasons:
- TOML has a more [concrete specification](https://toml.io/en/v1.0.0) than `.ini` files.
- There is now a built in python library for reading TOML files starting with Python 3.13.